### PR TITLE
CO-95 Expand datamodel with estimate fuelconsumption.

### DIFF
--- a/backend/Application.UnitTests/Locations/Commands/UpdateLocationMetaData/UpdateLocationMetaDataCommandTest.cs
+++ b/backend/Application.UnitTests/Locations/Commands/UpdateLocationMetaData/UpdateLocationMetaDataCommandTest.cs
@@ -42,6 +42,7 @@ namespace Application.UnitTests.Locations.Commands.UpdateLocationMetaData
       entity.FuelTank.TankNumber.Should().Be(command.TankNumber);
       entity.FuelTank.TankCapacity.Should().Be(command.TankCapacity);
       entity.FuelTank.MinimumFuelAmount.Should().Be(command.MinimumFuelAmount);
+      entity.EstimateFuelConsumption.Should().Be(command.EstimateConsumption);
     }
 
     [Fact]

--- a/backend/Application/Locations/Commands/UpdateLocationMetaData/UpdateLocationMetaDataCommand.cs
+++ b/backend/Application/Locations/Commands/UpdateLocationMetaData/UpdateLocationMetaDataCommand.cs
@@ -18,7 +18,6 @@ namespace Application.Locations.Commands.UpdateLocationMetaData
     public int TankNumber { get; set; }
     public double TankCapacity { get; set; }
     public double MinimumFuelAmount { get; set; }
-    //TODO Estiamte consumption isn't currently in the data model, but this is also a calculated property right?
     public double EstimateConsumption { get; set; }
 
     public class UpdateLocationMetaDataCommandHandler : IRequestHandler<UpdateLocationMetaDataCommand, int>
@@ -49,6 +48,7 @@ namespace Application.Locations.Commands.UpdateLocationMetaData
         location.Address = request.Address;
         location.Comments = request.Comment;
         location.Schedule = request.Refillschedule;
+        location.EstimateFuelConsumption = request.EstimateConsumption;
 
         var tank = location.FuelTank;
         tank.Type = request.TankType;

--- a/backend/Domain/Entities/Location.cs
+++ b/backend/Domain/Entities/Location.cs
@@ -17,5 +17,6 @@ namespace Domain.Entities
     public ICollection<Refill> Refills { get; set; }
     //Used with the interval schedule type.
     public int DaysBetweenRefills { get; set; }
+    public double EstimateFuelConsumption { get; set; }
   }
 }

--- a/backend/Infrastructure/Persistence/Migrations/20210121181559_FuelConsumption.Designer.cs
+++ b/backend/Infrastructure/Persistence/Migrations/20210121181559_FuelConsumption.Designer.cs
@@ -4,14 +4,16 @@ using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210121181559_FuelConsumption")]
+    partial class FuelConsumption
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Infrastructure/Persistence/Migrations/20210121181559_FuelConsumption.cs
+++ b/backend/Infrastructure/Persistence/Migrations/20210121181559_FuelConsumption.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Infrastructure.Persistence.Migrations
+{
+    public partial class FuelConsumption : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "EstimateFuelConsumption",
+                table: "Locations",
+                type: "float",
+                nullable: false,
+                defaultValue: 0.0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EstimateFuelConsumption",
+                table: "Locations");
+        }
+    }
+}

--- a/docs/entity-datamodel.md
+++ b/docs/entity-datamodel.md
@@ -23,6 +23,7 @@ class Location {
   comment
   refillSchedule
   daysBetweenRefills
+  estimateFuelConsumption
 }
 
 class FuelTank {


### PR DESCRIPTION
Wasn't able to perform the migration error message: `The operation failed because an index or statistics with name 'IX_Locations_RegionId' already exists on table 'Locations'`.