### PR TITLE
CO-96 Command to add location.

### DIFF
--- a/backend/Application.UnitTests/Locations/Commands/CreateLocation/CreateLocationCommandTest.cs
+++ b/backend/Application.UnitTests/Locations/Commands/CreateLocation/CreateLocationCommandTest.cs
@@ -1,0 +1,42 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Locations.Commands.CreateLocation;
+using Domain.Enums;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.UnitTests.Locations.Commands.CreateLocations
+{
+  public class CreateLocationCommandTest : CommandTestBase
+  {
+    [Fact]
+    public async Task Handle_ShouldPersistNewData()
+    {
+      var command = new CreateLocationCommand
+      {
+        Address = "This is address 23",
+        Comment = "This is comment.",
+        Refillschedule = RefillSchedule.AUTOMAIC,
+        TankType = TankType.BUILDING,
+        TankNumber = 9696,
+        TankCapacity = 4005.1,
+        MinimumFuelAmount = 50.5,
+        EstimateConsumption = 10
+      };
+
+      var handler = new CreateLocationCommand.CreateLocationCommandHandler(Context);
+      var result = await handler.Handle(command, CancellationToken.None);
+
+      var entity = Context.Locations.Find(result);
+
+      entity.Should().NotBeNull();
+      entity.Address.Should().Be(command.Address);
+      entity.Comments.Should().Be(command.Comment);
+      entity.Schedule.Should().Be(command.Refillschedule);
+      entity.FuelTank.Type.Should().Be(command.TankType);
+      entity.FuelTank.TankNumber.Should().Be(command.TankNumber);
+      entity.FuelTank.TankCapacity.Should().Be(command.TankCapacity);
+      entity.FuelTank.MinimumFuelAmount.Should().Be(command.MinimumFuelAmount);
+    }
+  }
+}

--- a/backend/Application/Locations/Commands/AddLocationImage/AddLocationImageCommand.cs
+++ b/backend/Application/Locations/Commands/AddLocationImage/AddLocationImageCommand.cs
@@ -12,7 +12,7 @@ using System.IO;
 using Application.Common.Options;
 using Microsoft.Extensions.Options;
 
-namespace Application.Locations.Commands.AddLocationImageCommand
+namespace Application.Locations.Commands.AddLocationImage
 {
   public class AddLocationImageCommand : IRequest<string>
   {

--- a/backend/Application/Locations/Commands/CreateLocation/CreateLocationCommands.cs
+++ b/backend/Application/Locations/Commands/CreateLocation/CreateLocationCommands.cs
@@ -1,0 +1,61 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+using global::Application.Common.Interfaces;
+using Application.Common.Exceptions;
+using Domain.Entities;
+
+namespace Application.Locations.Commands.CreateLocation
+{
+  public class CreateLocationCommand : IRequest<int>
+  {
+    public string Address { get; set; }
+    public string Comment { get; set; }
+    public int RegionId { get; set; }
+    public RefillSchedule Refillschedule { get; set; }
+    public TankType TankType { get; set; }
+    public int TankNumber { get; set; }
+    public double TankCapacity { get; set; }
+    public double MinimumFuelAmount { get; set; }
+    //TODO Estiamte consumption isn't currently in the data model. But is added with CO-95.
+    public double EstimateConsumption { get; set; }
+
+    public class CreateLocationCommandHandler : IRequestHandler<CreateLocationCommand, int>
+    {
+      private readonly IApplicationDbContext _context;
+
+      public CreateLocationCommandHandler(IApplicationDbContext context)
+      {
+        _context = context;
+      }
+
+      public async Task<int> Handle(CreateLocationCommand request, CancellationToken cancellationToken)
+      {
+        var tank = new FuelTank
+        {
+          Type = request.TankType,
+          TankCapacity = request.TankCapacity,
+          TankNumber = request.TankNumber,
+          MinimumFuelAmount = request.MinimumFuelAmount,
+          //TODO Estiamte consumption isn't currently in the data model. But is added with CO-95.
+        };
+        _context.FuelTanks.Add(tank);
+
+        var location = new Location
+        {
+          Address = request.Address,
+          Comments = request.Comment,
+          Schedule = request.Refillschedule,
+          RegionId = request.RegionId,
+          FuelTankId = tank.Id
+        };
+        _context.Locations.Add(location);
+
+        await _context.SaveChangesAsync(cancellationToken);
+        return location.Id;
+      }
+    }
+  }
+}

--- a/backend/Application/Locations/Commands/UpdateLocationMetaData/UpdateLocationMetaDataCommand.cs
+++ b/backend/Application/Locations/Commands/UpdateLocationMetaData/UpdateLocationMetaDataCommand.cs
@@ -5,12 +5,6 @@ using MediatR;
 using Domain.Enums;
 using Microsoft.EntityFrameworkCore;
 using Application.Common.Exceptions;
-using Microsoft.AspNetCore.Http;
-using System;
-using System.Text.RegularExpressions;
-using System.IO;
-using Application.Common.Options;
-using Microsoft.Extensions.Options;
 
 namespace Application.Locations.Commands.UpdateLocationMetaData
 {

--- a/backend/Web/Controllers/LocationController.cs
+++ b/backend/Web/Controllers/LocationController.cs
@@ -1,4 +1,4 @@
-using Application.Locations.Commands.AddLocationImageCommand;
+using Application.Locations.Commands.AddLocationImage;
 using Application.Locations.Commands.UpdateLocationMetaData;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;

--- a/backend/Web/Controllers/LocationController.cs
+++ b/backend/Web/Controllers/LocationController.cs
@@ -1,4 +1,5 @@
 using Application.Locations.Commands.AddLocationImage;
+using Application.Locations.Commands.CreateLocation;
 using Application.Locations.Commands.UpdateLocationMetaData;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -23,6 +24,11 @@ namespace Web.Controllers
         Picture = file,
         LocationId = id
       });
+    }
+    [HttpPost]
+    public async Task<ActionResult<int>> AddNewLocation(CreateLocationCommand command)
+    {
+      return await Mediator.Send(command);
     }
   }
 }

--- a/frontend/src/services/backend/nswagts.ts
+++ b/frontend/src/services/backend/nswagts.ts
@@ -532,6 +532,7 @@ export class HealthClient extends ClientBase implements IHealthClient {
 export interface ILocationClient {
     updateMetaData(command: UpdateLocationMetaDataCommand): Promise<number>;
     saveLocationImage(id: number, file?: FileParameter | null | undefined): Promise<string>;
+    addNewLocation(command: CreateLocationCommand): Promise<number>;
 }
 
 export class LocationClient extends ClientBase implements ILocationClient {
@@ -627,6 +628,46 @@ export class LocationClient extends ClientBase implements ILocationClient {
             });
         }
         return Promise.resolve<string>(<any>null);
+    }
+
+    addNewLocation(command: CreateLocationCommand): Promise<number> {
+        let url_ = this.baseUrl + "/api/Location";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(command);
+
+        let options_ = <RequestInit>{
+            body: content_,
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.transformOptions(options_).then(transformedOptions_ => {
+            return this.http.fetch(url_, transformedOptions_);
+        }).then((_response: Response) => {
+            return this.processAddNewLocation(_response);
+        });
+    }
+
+    protected processAddNewLocation(response: Response): Promise<number> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = resultData200 !== undefined ? resultData200 : <any>null;
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<number>(<any>null);
     }
 }
 
@@ -1450,6 +1491,74 @@ export enum TankType {
     BUILDING = 0,
     SHIP = 1,
     TANK = 2,
+}
+
+export class CreateLocationCommand implements ICreateLocationCommand {
+    address?: string | undefined;
+    comment?: string | undefined;
+    regionId?: number;
+    refillschedule?: RefillSchedule;
+    tankType?: TankType;
+    tankNumber?: number;
+    tankCapacity?: number;
+    minimumFuelAmount?: number;
+    estimateConsumption?: number;
+
+    constructor(data?: ICreateLocationCommand) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.address = _data["address"];
+            this.comment = _data["comment"];
+            this.regionId = _data["regionId"];
+            this.refillschedule = _data["refillschedule"];
+            this.tankType = _data["tankType"];
+            this.tankNumber = _data["tankNumber"];
+            this.tankCapacity = _data["tankCapacity"];
+            this.minimumFuelAmount = _data["minimumFuelAmount"];
+            this.estimateConsumption = _data["estimateConsumption"];
+        }
+    }
+
+    static fromJS(data: any): CreateLocationCommand {
+        data = typeof data === 'object' ? data : {};
+        let result = new CreateLocationCommand();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["address"] = this.address;
+        data["comment"] = this.comment;
+        data["regionId"] = this.regionId;
+        data["refillschedule"] = this.refillschedule;
+        data["tankType"] = this.tankType;
+        data["tankNumber"] = this.tankNumber;
+        data["tankCapacity"] = this.tankCapacity;
+        data["minimumFuelAmount"] = this.minimumFuelAmount;
+        data["estimateConsumption"] = this.estimateConsumption;
+        return data; 
+    }
+}
+
+export interface ICreateLocationCommand {
+    address?: string | undefined;
+    comment?: string | undefined;
+    regionId?: number;
+    refillschedule?: RefillSchedule;
+    tankType?: TankType;
+    tankNumber?: number;
+    tankCapacity?: number;
+    minimumFuelAmount?: number;
+    estimateConsumption?: number;
 }
 
 export class CreateRefillCommand implements ICreateRefillCommand {


### PR DESCRIPTION
The location update command already exists, so I added in the other command described in the main story of CO-94 which is being able to add in completely new locations. 

The command as of right now also takes information about a related fuel tank and immediately creates a new fuel tank as well. Should this be removed from this command and moved into its own command?